### PR TITLE
Add per-user MT5 execution gateway and deployment tooling

### DIFF
--- a/AI_service/AI_service/settings.py
+++ b/AI_service/AI_service/settings.py
@@ -11,7 +11,9 @@ https://docs.djangoproject.com/en/5.2/ref/settings/
 """
 
 from decouple import config, Csv
+import dj_database_url
 from pathlib import Path
+from cryptography.fernet import Fernet
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
@@ -72,13 +74,9 @@ WSGI_APPLICATION = 'AI_service.wsgi.application'
 
 
 # Database
-# https://docs.djangoproject.com/en/5.2/ref/settings/#databases
-
+# Use DATABASE_URL if provided, defaulting to local SQLite
 DATABASES = {
-    'default': {
-        'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': BASE_DIR / 'db.sqlite3',
-    }
+    'default': dj_database_url.config(default=f'sqlite:///{BASE_DIR / "db.sqlite3"}')
 }
 
 
@@ -117,6 +115,7 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/5.2/howto/static-files/
 
 STATIC_URL = 'static/'
+STATIC_ROOT = BASE_DIR / 'staticfiles'
 
 # Default primary key field type
 # https://docs.djangoproject.com/en/5.2/ref/settings/#default-auto-field
@@ -155,3 +154,10 @@ BOT_PAUSED    = False
 TRIAL_DAYS    = config('TRIAL_DAYS', default=7, cast=int)
 GRACE_HOURS   = config('GRACE_HOURS', default=24, cast=int)
 MAX_MSG_RATE  = config('MAX_MSG_RATE', default=30.0, cast=float)
+
+# Optional external MT5 executor
+EXECUTOR_URL   = config('EXECUTOR_URL', default=None)
+EXECUTOR_TOKEN = config('EXECUTOR_TOKEN', default=None)
+
+# Encryption key for MT5 credentials (Fernet)
+MT5_ENC_KEY = config('MT5_ENC_KEY', default=Fernet.generate_key().decode())

--- a/AI_service/core/execution.py
+++ b/AI_service/core/execution.py
@@ -1,0 +1,88 @@
+import asyncio
+import requests
+import MetaTrader5 as mt5
+from datetime import datetime
+from django.conf import settings
+from cryptography.fernet import Fernet
+from .models import TradeOrder, ExecutionAttempt, Subscription
+
+_user_locks = {}
+_fernet = Fernet(settings.MT5_ENC_KEY.encode())
+
+
+def _decrypt(value: str) -> str:
+    try:
+        return _fernet.decrypt(value.encode()).decode()
+    except Exception:
+        return value
+
+async def execute_order(user, sig, size, request):
+    """Execute an MT5 order for a specific user with per-user locking."""
+    lock = _user_locks.setdefault(user.id, asyncio.Lock())
+    async with lock:
+        sub = Subscription.objects.get(user=user)
+        start = datetime.utcnow()
+        result_data = {}
+        comment = ''
+        retcode = -1
+        if settings.EXECUTOR_URL:
+            url = settings.EXECUTOR_URL.rstrip('/') + '/order'
+            payload = {
+                'server': _decrypt(sub.mt5_server),
+                'login': _decrypt(sub.mt5_login),
+                'password': _decrypt(sub.mt5_password),
+                'request': request,
+            }
+            headers = {}
+            if settings.EXECUTOR_TOKEN:
+                headers['Authorization'] = f'Bearer {settings.EXECUTOR_TOKEN}'
+            loop = asyncio.get_running_loop()
+            def _post():
+                return requests.post(url, json=payload, headers=headers, timeout=15)
+            resp = await loop.run_in_executor(None, _post)
+            try:
+                result_data = resp.json()
+                retcode = result_data.get('retcode', -1)
+                comment = result_data.get('comment', '')
+            except Exception:
+                comment = 'executor error'
+        else:
+            loop = asyncio.get_running_loop()
+            def _send():
+                if not mt5.initialize(server=_decrypt(sub.mt5_server), login=int(_decrypt(sub.mt5_login)), password=_decrypt(sub.mt5_password)):
+                    return {'retcode': -1, 'comment': 'init failed'}
+                try:
+                    if 'price' not in request:
+                        tick = mt5.symbol_info_tick(request['symbol'])
+                        if request['type'] == mt5.ORDER_TYPE_BUY:
+                            request['price'] = tick.ask
+                        else:
+                            request['price'] = tick.bid
+                    res = mt5.order_send(request)
+                    return res._asdict()
+                finally:
+                    mt5.shutdown()
+            result_data = await loop.run_in_executor(None, _send)
+            retcode = result_data.get('retcode', -1)
+            comment = result_data.get('comment', '')
+        end = datetime.utcnow()
+        status = 'EXECUTED' if retcode == mt5.TRADE_RETCODE_DONE else 'FAILED'
+        order = TradeOrder.objects.create(
+            user=user,
+            signal=sig,
+            size=size,
+            status=status,
+            placed_at=start,
+            executed_at=end,
+            profit_loss=0.0,
+        )
+        ExecutionAttempt.objects.create(
+            trade_order=order,
+            attempt_number=1,
+            request_payload=request,
+            response_data=result_data,
+            duration_ms=int((end-start).total_seconds()*1000),
+            success=status == 'EXECUTED',
+            error_message=comment,
+        )
+        return retcode, comment

--- a/AI_service/core/migrations/0004_encrypt_mt5_fields.py
+++ b/AI_service/core/migrations/0004_encrypt_mt5_fields.py
@@ -1,0 +1,52 @@
+from django.db import migrations
+from django.conf import settings
+import base64
+from cryptography.fernet import Fernet
+
+
+def forwards(apps, schema_editor):
+    Subscription = apps.get_model('core', 'Subscription')
+    f = Fernet(settings.MT5_ENC_KEY.encode())
+    for sub in Subscription.objects.all():
+        updated = False
+        for field in ['mt5_server', 'mt5_login', 'mt5_password']:
+            value = getattr(sub, field)
+            if not value:
+                continue
+            try:
+                decoded = base64.b64decode(value).decode()
+            except Exception:
+                decoded = value
+            encrypted = f.encrypt(decoded.encode()).decode()
+            setattr(sub, field, encrypted)
+            updated = True
+        if updated:
+            sub.save(update_fields=['mt5_server', 'mt5_login', 'mt5_password'])
+
+
+def backwards(apps, schema_editor):
+    Subscription = apps.get_model('core', 'Subscription')
+    f = Fernet(settings.MT5_ENC_KEY.encode())
+    for sub in Subscription.objects.all():
+        for field in ['mt5_server', 'mt5_login', 'mt5_password']:
+            value = getattr(sub, field)
+            if not value:
+                continue
+            try:
+                decrypted = f.decrypt(value.encode()).decode()
+            except Exception:
+                decrypted = value
+            encoded = base64.b64encode(decrypted.encode()).decode()
+            setattr(sub, field, encoded)
+        sub.save(update_fields=['mt5_server', 'mt5_login', 'mt5_password'])
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('core', '0003_alter_subscription_news_window_minutes_and_more'),
+    ]
+
+    operations = [
+        migrations.RunPython(forwards, backwards),
+    ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,12 @@
+Django
+gunicorn
+python-decouple
+dj-database-url
+telethon
+google-cloud-vision
+openai
+apscheduler
+requests
+cryptography
+MetaTrader5
+Pillow

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -e
+pip install -r requirements.txt
+python AI_service/manage.py migrate --noinput
+python AI_service/manage.py collectstatic --noinput
+if [ -n "$GVISION_JSON_B64" ]; then
+  echo "$GVISION_JSON_B64" | base64 -d > gvision.json
+  export GOOGLE_APPLICATION_CREDENTIALS=$(pwd)/gvision.json
+fi
+python AI_service/manage.py runbot &
+gunicorn AI_service.wsgi:application --bind 0.0.0.0:${PORT:-8000}


### PR DESCRIPTION
## Summary
- add Fernet-encrypted MT5 credential migration and execution gateway with per-user locks
- wire Telegram bot to use central `execute_order` and new deployment start script
- configure database via `dj-database-url` and collect static files on deploy

## Testing
- `python AI_service/manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6895db78c3bc83209504fe1eb688358e